### PR TITLE
Change images to render pixelated inside plugin about

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -146,3 +146,8 @@ td, th {
 	line-height: 24px;
 	margin-bottom: 15px;
 }
+
+.plugin img {
+    image-rendering: pixelated;
+    -ms-interpolation-mode: nearest-neighbor;
+}

--- a/pages/plugins/_.vue
+++ b/pages/plugins/_.vue
@@ -123,7 +123,6 @@ export default {
 	html.dark-mode .plugin {
 		background: var(--dark-ui);
 	}
-
 	.plugin .title {
 		display: inline-block;
 		margin-bottom: 4px;
@@ -141,11 +140,13 @@ export default {
 	.plugin .min_version {
 		color: var(--light-subtle);
 	}
+    .plugin img {
+        image-rendering: pixelated;
+    }
 	h4 {
 		margin-bottom: 4px;
 		margin-top: 20px;
 	}
-
 	.plugin_tag_list {
 		padding: 0;
 		margin-bottom: 5px;

--- a/pages/plugins/_.vue
+++ b/pages/plugins/_.vue
@@ -140,9 +140,6 @@ export default {
 	.plugin .min_version {
 		color: var(--light-subtle);
 	}
-    .plugin img {
-        image-rendering: pixelated;
-    }
 	h4 {
 		margin-bottom: 4px;
 		margin-top: 20px;


### PR DESCRIPTION
Inside blockbench, images in the about section of a plugin render pixelated, this changes makes it so that this behaviour is consistent on the website.