### PR TITLE
typo: replaced cube with locator

### DIFF
--- a/content/api/outliner.md
+++ b/content/api/outliner.md
@@ -281,7 +281,7 @@ Resizes the cube by a specified amount
 
 ## Locator
 
-### new Cube( data ).init()
+### new Locator( data ).init()
 
 Creates a new locator and initializes it.
 
@@ -289,7 +289,7 @@ Creates a new locator and initializes it.
 * `from: Array` Position of the locator in local space
 * `export: Boolean` Whether to include the locator in exported files.
 
-#### Cube#extend( data: Object )
+#### Locator#extend( data: Object )
 Copies properties from data to the locator.
 
 #### Locator#getUndoCopy( aspects )


### PR DESCRIPTION
Locator initialization and the extend method examples had "Cube" rather than "Locator"