### PR TITLE
Update macOS downloads section (minor)

### DIFF
--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -46,11 +46,11 @@
 						<div class="install_os">
 							<fa :icon="['fab', 'apple']" />
 							<h3>macOS</h3>
-							<a class="blockbench_download mac" :href="`${path}/v${version}/Blockbench_x64_${version}.dmg`" target="_blank" rel="noopener">
-								<label>macOS Intel</label>
-							</a>
 							<a class="blockbench_download mac" :href="`${path}/v${version}/Blockbench_arm64_${version}.dmg`" target="_blank" rel="noopener">
 								<label>macOS Apple Silicon</label>
+							</a>
+							<a class="blockbench_download mac" :href="`${path}/v${version}/Blockbench_x64_${version}.dmg`" target="_blank" rel="noopener">
+								<label>macOS Intel</label>
 							</a>
 						</div>
 						

--- a/pages/downloads.vue
+++ b/pages/downloads.vue
@@ -47,10 +47,10 @@
 							<fa :icon="['fab', 'apple']" />
 							<h3>macOS</h3>
 							<a class="blockbench_download mac" :href="`${path}/v${version}/Blockbench_arm64_${version}.dmg`" target="_blank" rel="noopener">
-								<label>macOS Apple Silicon</label>
+								<label>Apple silicon</label>
 							</a>
 							<a class="blockbench_download mac" :href="`${path}/v${version}/Blockbench_x64_${version}.dmg`" target="_blank" rel="noopener">
-								<label>macOS Intel</label>
+								<label>Intel chip</label>
 							</a>
 						</div>
 						


### PR DESCRIPTION
- Swaps the macOS download order — Apple silicon first — as it's now the primary Mac architecture
- Updates the link titles to reduce the presence of "macOS" 3x
  - "silicon" is not capitalized as Apple themselves does not do so
  - Same naming convention as [VS Code](https://github.com/JannisX11/blockbench.net/assets/88053191/73bd789e-b6b9-4f40-8261-878db27f9d17)

<img width="250" alt="Preview of PR changes" src="https://github.com/JannisX11/blockbench.net/assets/88053191/fa6bb5b4-093a-4b31-8d93-f2d643deb017">